### PR TITLE
Correct Date/time seconds for floating point imprecision

### DIFF
--- a/lib/Data/XLSX/Parser/Sheet.pm
+++ b/lib/Data/XLSX/Parser/Sheet.pm
@@ -145,6 +145,8 @@ sub _convert_serial_time {
 
     # UNIX Epoch(1970/1/1 00:00:00) is 25569.0
     my $epoch = ($serial_time - 25569) * 24 * 60 * 60;
+    # round to nearest second to compensate for floating point errors
+    $epoch = $epoch > 0 ? int( $epoch + 0.5) : int( $epoch - 0.5);
     return Time::Piece::gmtime($epoch);
 }
 

--- a/t/_serial_time.t
+++ b/t/_serial_time.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Data::XLSX::Parser::Sheet;
+use Data::Dumper;
+my $dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,41935.171365740738);
+is( $dt->datetime(),'2014-10-23T04:06:46' , "datetime pos below");
+
+$dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,41935.171365740750);
+is( $dt->datetime(),'2014-10-23T04:06:46' , "datetime pos above");
+
+#$dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,61.171365740738);
+$dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,61.171365740700);
+is( $dt->datetime(),'1900-03-01T04:06:46' , "datetime neg below");
+
+#$dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,61.171365740750);
+$dt =  Data::XLSX::Parser::Sheet::_convert_serial_time(0,61.17136574090);
+is( $dt->datetime(),'1900-03-01T04:06:46' , "datetime neg above");
+
+done_testing;


### PR DESCRIPTION
Excel seconds are inexact due to floating point imprecision.  Round to nearest second in Sheet::_serial_time().

Add tests for _serial_time().